### PR TITLE
Update the ghpages action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,51 @@
-name: GitHub Pages
+name: Deploy to GitHub Pages
 
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
-  deploy:
+  build:
+    name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main docs repo
-        uses: actions/checkout@v3
-      - name: Setup Docusaurus
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
         with:
-          node-version: 20.x
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
           cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Build website
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        env:
+          NODE_OPTIONS: "--max_old_space_size=7168"
+        run: yarn build --no-minify
+
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          path: build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+    
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The rules for GitHub actions for all Rancher repos have been updated and only a set of specific images are accepted.

Copied the `deploy.yml` from Rancher Docs.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com