### PR TITLE
Updated baseUrl

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,7 +18,7 @@ const config = {
   url: 'https://rancherlabs.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/devex-designs/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
For the live website, the baseUrl needs to be set to "/" instead of "/devex-designs"

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com