### PR TITLE
Remove ref to internal slack channel

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -15,10 +15,6 @@ continuous deployment, security, and maintainability.
 Some designs will use SUSE Rancher Prime components, while others will
 incorporate features available from SUSE certified partners.
 
-Discussion about this initiative is currently happening in the SUSE [#proj-devx](https://app.slack.com/client/T02863RC2AC/C088797UWCA) Slack channel
-(internal), but will expand to the wider SUSE Rancher community at and
-after SUSECON 2025.
-
 ## 1. Rancher GitOps 
 
 ### A composable, customizable, Git-centered workflow


### PR DESCRIPTION
There are a lot of external eyes on the site now. No point calling out a channel they can't get to (public channel will come soon though).